### PR TITLE
Use case-insensitive tag when matching bodystructure body.

### DIFF
--- a/imap-proto/src/body_structure.rs
+++ b/imap-proto/src/body_structure.rs
@@ -76,7 +76,7 @@ named!(body_type_basic<BodyStructure>, do_parse!(
 ));
 
 named!(body_type_text<BodyStructure>, do_parse!(
-    tag_s!("\"TEXT\"") >>
+    tag_no_case_s!("\"TEXT\"") >>
     space >>
     media_subtype: string_utf8 >>
     space >>
@@ -113,7 +113,7 @@ named!(body_type_text<BodyStructure>, do_parse!(
 ));
 
 named!(body_type_message<BodyStructure>, do_parse!(
-    tag_s!("\"MESSAGE\" \"RFC822\"") >>
+    tag_no_case_s!("\"MESSAGE\" \"RFC822\"") >>
     space >>
     param: body_param >>
     space >>


### PR DESCRIPTION
Implementation must support servers that do not return the media type in all uppercase.
Example: Dovecot returns `BODYSTRUCTURE ("text" "plain" ("charset" "us-ascii") NIL NIL "quoted-printable" 16 2 NIL NIL NIL NIL)`.